### PR TITLE
Basic example showing client setup and listing projects

### DIFF
--- a/examples/basic.go
+++ b/examples/basic.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/rsclarke/go-nucleus/nucleus"
+)
+
+func main() {
+	tp := nucleus.APIKeyTransport{
+		APIKey: os.Getenv("NUCLEUS_API_KEY"),
+	}
+
+	client := nucleus.NewClient(os.Getenv("NUCLEUS_ORG"), tp.Client())
+	ctx := context.Background()
+
+	projects, _, err := client.Projects.ListProjects(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Print all project names
+	for _, project := range projects {
+		fmt.Println(project.Name)
+	}
+}


### PR DESCRIPTION
Simple example showing client setup using the `APIKeyTransport` and using the `ListProjects` API call.