### PR TITLE
use string type for projectID

### DIFF
--- a/nucleus/projects.go
+++ b/nucleus/projects.go
@@ -36,8 +36,8 @@ func (s *ProjectsService) ListProjects(ctx context.Context) ([]*Project, *http.R
 }
 
 // GetProject returns details on a specific project
-func (s *ProjectsService) GetProject(ctx context.Context, id int64) (*Project, *http.Response, error) {
-	u := fmt.Sprintf("projects/%v", id)
+func (s *ProjectsService) GetProject(ctx context.Context, projectID string) (*Project, *http.Response, error) {
+	u := fmt.Sprintf("projects/%v", projectID)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/nucleus/projects_assessments.go
+++ b/nucleus/projects_assessments.go
@@ -58,14 +58,14 @@ type AssessmentData struct {
 
 // Assessment a conducted assessment of the project
 type Assessment struct {
-	ProjectID       int              `json:"project_id"`
+	ProjectID       string           `json:"project_id"`
 	Data            []AssessmentData `json:"assessment_data"`
-	ParentProjectID int              `json:"parent_project_id"`
+	ParentProjectID string           `json:"parent_project_id"`
 	Name            string           `json:"assessment_name"`
 }
 
 // ListAssessments returns all assessments for a given project id
-func (s *ProjectsService) ListAssessments(ctx context.Context, projectID int64) ([]*Assessment, *http.Response, error) {
+func (s *ProjectsService) ListAssessments(ctx context.Context, projectID string) ([]*Assessment, *http.Response, error) {
 	u := fmt.Sprintf("projects/%v/assessments", projectID)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {


### PR DESCRIPTION
Although project IDs are int64, their of type string in JSON response.